### PR TITLE
Allow using MacroDeck variables in WriteScript Actions

### DIFF
--- a/Actions/WriteScriptAction.cs
+++ b/Actions/WriteScriptAction.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 using jbcarreon123.AHKPlugin.Languages;
 using SuchByte.MacroDeck.Logging;
 using SuchByte.MacroDeck;
@@ -34,6 +35,21 @@ namespace jbcarreon123.AHKPlugin.Actions
 
             try
             {
+                string pattern = @"{{\s?\w+\s?}}";
+                foreach (Match match in Regex.Matches(script, pattern))
+                {
+                    string var_name = match.Value.Replace("{{", "").Replace("}}", "").Trim();
+                    try
+                    {
+                        string var_value = VariableManager.ListVariables.FirstOrDefault(v => v.Name.Equals(var_name)).Value;
+                        script = script.Replace(match.Value, var_value);
+                    }
+                    catch (Exception e)
+                    {
+                        MacroDeckLogger.Error(PluginInstance.Main, $"Could not load variable with name \"{var_name}\": {e}");
+                    }
+                }
+
                 File.WriteAllText(MacroDeck.TempDirectoryPath + "\\" + rnd + ".ahk", script);
                 System.Diagnostics.Process proc = new System.Diagnostics.Process();
                 proc.StartInfo.FileName = pth + "\\AutoHotkeyU64.exe";

--- a/Actions/WriteScriptAction.cs
+++ b/Actions/WriteScriptAction.cs
@@ -35,20 +35,17 @@ namespace jbcarreon123.AHKPlugin.Actions
 
             try
             {
-                string pattern = @"{{\s?\w+\s?}}";
-                foreach (Match match in Regex.Matches(script, pattern))
-                {
-                    string var_name = match.Value.Replace("{{", "").Replace("}}", "").Trim();
-                    try
-                    {
-                        string var_value = VariableManager.ListVariables.FirstOrDefault(v => v.Name.Equals(var_name)).Value;
-                        script = script.Replace(match.Value, var_value);
-                    }
-                    catch (Exception e)
-                    {
-                        MacroDeckLogger.Error(PluginInstance.Main, $"Could not load variable with name \"{var_name}\": {e}");
-                    }
-                }
+                // Render script with variables
+                // Ensure we keep AHK '{' and '}' alive
+                script = script.Replace("{{", "_COTTLE_PLACEHOLDER_OPEN_");
+                script = script.Replace("}}", "_COTTLE_PLACEHOLDER_CLOSE_");
+                script = script.Replace("{", "_AHK_PLACEHOLDER_OPEN_");
+                script = script.Replace("}", "_AHK_PLACEHOLDER_CLOSE_");
+                script = script.Replace("_COTTLE_PLACEHOLDER_OPEN_", "{");
+                script = script.Replace("_COTTLE_PLACEHOLDER_CLOSE_", "}");
+                script = VariableManager.RenderTemplate(script);
+                script = script.Replace("_AHK_PLACEHOLDER_OPEN_", "{");
+                script = script.Replace("_AHK_PLACEHOLDER_CLOSE_", "}");
 
                 File.WriteAllText(MacroDeck.TempDirectoryPath + "\\" + rnd + ".ahk", script);
                 System.Diagnostics.Process proc = new System.Diagnostics.Process();

--- a/Actions/WriteScriptAction.cs
+++ b/Actions/WriteScriptAction.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
 using jbcarreon123.AHKPlugin.Languages;
 using SuchByte.MacroDeck.Logging;
 using SuchByte.MacroDeck;

--- a/Actions/WriteScriptv2Action.cs
+++ b/Actions/WriteScriptv2Action.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
 using jbcarreon123.AHKPlugin.Languages;
 using Newtonsoft.Json.Linq;
 using System.IO;

--- a/Actions/WriteScriptv2Action.cs
+++ b/Actions/WriteScriptv2Action.cs
@@ -35,20 +35,17 @@ namespace jbcarreon123.AHKPlugin.Actions
 
             try
             {
-                string pattern = @"{{\s?\w+\s?}}";
-                foreach (Match match in Regex.Matches(script, pattern))
-                {
-                    string var_name = match.Value.Replace("{{", "").Replace("}}", "").Trim();
-                    try
-                    {
-                        string var_value = VariableManager.ListVariables.FirstOrDefault(v => v.Name.Equals(var_name)).Value;
-                        script = script.Replace(match.Value, var_value);
-                    }
-                    catch (Exception e)
-                    {
-                        MacroDeckLogger.Error(PluginInstance.Main, $"Could not load variable with name \"{var_name}\": {e}");
-                    }
-                }
+                // Render script with variables
+                // Ensure we keep AHK '{' and '}' alive
+                script = script.Replace("{{", "_COTTLE_PLACEHOLDER_OPEN_");
+                script = script.Replace("}}", "_COTTLE_PLACEHOLDER_CLOSE_");
+                script = script.Replace("{", "_AHK_PLACEHOLDER_OPEN_");
+                script = script.Replace("}", "_AHK_PLACEHOLDER_CLOSE_");
+                script = script.Replace("_COTTLE_PLACEHOLDER_OPEN_", "{");
+                script = script.Replace("_COTTLE_PLACEHOLDER_CLOSE_", "}");
+                script = VariableManager.RenderTemplate(script);
+                script = script.Replace("_AHK_PLACEHOLDER_OPEN_", "{");
+                script = script.Replace("_AHK_PLACEHOLDER_CLOSE_", "}");
 
                 File.WriteAllText(MacroDeck.TempDirectoryPath + "\\" + rnd + ".ahk", script);
                 System.Diagnostics.Process proc = new System.Diagnostics.Process();

--- a/Actions/WriteScriptv2Action.cs
+++ b/Actions/WriteScriptv2Action.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 using jbcarreon123.AHKPlugin.Languages;
 using Newtonsoft.Json.Linq;
 using System.IO;
@@ -34,6 +35,21 @@ namespace jbcarreon123.AHKPlugin.Actions
 
             try
             {
+                string pattern = @"{{\s?\w+\s?}}";
+                foreach (Match match in Regex.Matches(script, pattern))
+                {
+                    string var_name = match.Value.Replace("{{", "").Replace("}}", "").Trim();
+                    try
+                    {
+                        string var_value = VariableManager.ListVariables.FirstOrDefault(v => v.Name.Equals(var_name)).Value;
+                        script = script.Replace(match.Value, var_value);
+                    }
+                    catch (Exception e)
+                    {
+                        MacroDeckLogger.Error(PluginInstance.Main, $"Could not load variable with name \"{var_name}\": {e}");
+                    }
+                }
+
                 File.WriteAllText(MacroDeck.TempDirectoryPath + "\\" + rnd + ".ahk", script);
                 System.Diagnostics.Process proc = new System.Diagnostics.Process();
                 proc.StartInfo.FileName = pth + "\\AutoHotkey.exe";

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Choose your existing AHK script file and leave it! It will now work!
 or, Write a new AHK script and leave it! AHK Plugin will run it if you pressed the action button!
 
 ### Variables
-Writing scripts within Macro-Deck allows using Variables. Variable names have to be enclosed in `{{` and `}}` (example `{{ my_variable }}`). 
+Writing scripts within Macro-Deck allows using Variables. Since AHK makes use of `{` and `}` we use double `{{` and `}}` to indicate a Variable in AWH WriteScripts (example `{{my_variable}}`).
 Example:
 ```
 MsgBox, It is now {{time}} and the date is {{date}}.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Choose your existing AHK script file and leave it! It will now work!
 ## Write and Run AutoHotkey scripts
 or, Write a new AHK script and leave it! AHK Plugin will run it if you pressed the action button!
 
+### Variables
+Writing scripts within Macro-Deck allows using Variables. Variable names have to be enclosed in `{{` and `}}` (example `{{ my_variable }}`). 
+Example:
+```
+MsgBox, It is now {{time}} and the date is {{date}}.
+```
+
 ## Automation
 Use AHK Plugin with other plugins for automated tasks in Macro Deck!
 


### PR DESCRIPTION
This provides the ability to use variables in WriteScript Actions (implementing https://github.com/jbcarreon123/MacroDeck2-AHKPlugin/issues/9)

It uses an obsolete method, however I hope this gets sorted out in the future: https://github.com/Macro-Deck-org/Macro-Deck/issues/299.